### PR TITLE
Feat: Hex color fix

### DIFF
--- a/bot/commands.py
+++ b/bot/commands.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 import discord
 from discord import app_commands
 from discord.ext import commands
-from config.config import load_config, update_config, RESTART_REQUIRED_KEYS, get_configurable_options, CONFIG_PATH
+from config.config import load_config, update_config, RESTART_REQUIRED_KEYS, get_configurable_options, CONFIG_PATH, format_hex_color
 from i18n import load_translations
 from graphs.generate_graphs import update_and_post_graphs
 from graphs.generate_graphs_user import generate_user_graphs
@@ -85,6 +85,8 @@ class Commands(commands.Cog):
                     value = value.lower() == 'true'
                 elif isinstance(config.get(key), int):
                     value = int(value)
+                elif key in ['TV_COLOR', 'MOVIE_COLOR']:
+                    value = format_hex_color(value)
 
                 # Update configuration
                 old_value = config.get(key, "N/A")

--- a/bot/commands.py
+++ b/bot/commands.py
@@ -1,5 +1,4 @@
 # bot/commands.py
-import os
 from datetime import datetime, timedelta
 import discord
 from discord import app_commands

--- a/bot/commands.py
+++ b/bot/commands.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 import discord
 from discord import app_commands
 from discord.ext import commands
-from config.config import load_config, update_config, RESTART_REQUIRED_KEYS, get_configurable_options, CONFIG_PATH, format_hex_color
+from config.config import load_config, update_config, RESTART_REQUIRED_KEYS, get_configurable_options, CONFIG_PATH, format_color_value
 from i18n import load_translations
 from graphs.generate_graphs import update_and_post_graphs
 from graphs.generate_graphs_user import generate_user_graphs
@@ -86,7 +86,7 @@ class Commands(commands.Cog):
                 elif isinstance(config.get(key), int):
                     value = int(value)
                 elif key in ['TV_COLOR', 'MOVIE_COLOR']:
-                    value = format_hex_color(value)
+                    value = format_color_value(value)
 
                 # Update configuration
                 old_value = config.get(key, "N/A")

--- a/config/config.py
+++ b/config/config.py
@@ -2,7 +2,6 @@
 import os
 import yaml
 import argparse
-from datetime import datetime, timezone
 
 # Get the CONFIG_DIR from environment variable, default to current directory if not set
 CONFIG_DIR = os.environ.get('CONFIG_DIR', os.getcwd())

--- a/config/config.py
+++ b/config/config.py
@@ -32,16 +32,8 @@ def format_hex_color(color):
     # Remove any existing quotes and spaces
     color = color.strip().strip('"\'')
     
-    # Check if it's a valid hex color
-    if re.match(r'^#(?:[0-9a-fA-F]{3}){1,2}$', color):
-        # Return the color wrapped in double quotes
-        return f'"{color}"'
-    elif re.match(r'^[0-9a-fA-F]{6}$', color):
-        # If it's a valid hex color without #, add it and wrap in quotes
-        return f'"#{color}"'
-    else:
-        # If it's not a hex color, return as is (might be a named color)
-        return color
+    # Always wrap the color in double quotes, regardless of its validity
+    return f'"{color}"'
 
 def load_config(config_path=CONFIG_PATH, reload=False):
     global config

--- a/config/config.py
+++ b/config/config.py
@@ -2,7 +2,6 @@
 import os
 import yaml
 import argparse
-import re
 
 # Get the CONFIG_DIR from environment variable, default to current directory if not set
 CONFIG_DIR = os.environ.get('CONFIG_DIR', os.getcwd())
@@ -28,12 +27,11 @@ CONFIGURABLE_OPTIONS = [
 # Global variable to store the configuration
 config = None
 
-def format_hex_color(color):
+def format_color_value(value):
     # Remove any existing quotes and spaces
-    color = color.strip().strip('"\'')
-    
-    # Always wrap the color in double quotes, regardless of its validity
-    return f'"{color}"'
+    value = value.strip().strip('"\'')
+    # Always wrap the value in double quotes
+    return f'"{value}"'
 
 def load_config(config_path=CONFIG_PATH, reload=False):
     global config
@@ -47,8 +45,8 @@ def load_config(config_path=CONFIG_PATH, reload=False):
         # Function to get the value from config.yml or environment variable
         def get_config(key, default=None):
             value = config_vars.get(key, os.getenv(key, default))
-            if key in ['TV_COLOR', 'MOVIE_COLOR'] and value is not None:
-                return format_hex_color(value)
+            if key in ['TV_COLOR', 'MOVIE_COLOR']:
+                return format_color_value(str(value))
             return value
 
         config = {
@@ -93,14 +91,14 @@ def save_config(config, config_path=CONFIG_PATH):
             if key in config:
                 value = config[key]
                 if key in ['TV_COLOR', 'MOVIE_COLOR']:
-                    value = format_hex_color(value)
+                    value = format_color_value(str(value))
                 lines[i] = f"{key}: {value}\n"
                 del config[key]
 
     # Append any new keys at the end
     for key, value in config.items():
         if key in ['TV_COLOR', 'MOVIE_COLOR']:
-            value = format_hex_color(value)
+            value = format_color_value(str(value))
         lines.append(f"{key}: {value}\n")
 
     with open(config_path, 'w') as file:
@@ -111,7 +109,7 @@ def update_config(key, value):
     config = load_config(reload=True)
     
     if key in ['TV_COLOR', 'MOVIE_COLOR']:
-        value = format_hex_color(value)
+        value = format_color_value(str(value))
     
     config[key] = value
     save_config(config)
@@ -125,7 +123,7 @@ def sanitize_config_file():
     for i, line in enumerate(lines):
         if 'COLOR:' in line:
             key, value = line.split(':', 1)
-            formatted_value = format_hex_color(value.strip())
+            formatted_value = format_color_value(value.strip())
             if formatted_value != value.strip():
                 lines[i] = f"{key}: {formatted_value}\n"
                 updated = True

--- a/config/config.yml.sample
+++ b/config/config.yml.sample
@@ -18,8 +18,8 @@ ENABLE_TOP_10_USERS: true
 ENABLE_PLAY_COUNT_BY_MONTH: true
 
 # Graph colors
-TV_COLOR: '#1f77b4'
-MOVIE_COLOR: '#ff7f0e'
+TV_COLOR: "#1f77b4"
+MOVIE_COLOR: "#ff7f0e"
 
 # Annotation options
 ANNOTATE_DAILY_PLAY_COUNT: true

--- a/graphs/generate_graphs.py
+++ b/graphs/generate_graphs.py
@@ -8,7 +8,6 @@ import matplotlib.pyplot as plt
 from datetime import datetime, timedelta
 from matplotlib.ticker import MaxNLocator
 from matplotlib.dates import DateFormatter
-from matplotlib.font_manager import FontProperties
 from config.config import load_config, CONFIG_PATH
 from i18n import load_translations
 

--- a/graphs/generate_graphs.py
+++ b/graphs/generate_graphs.py
@@ -18,8 +18,8 @@ config = load_config(CONFIG_PATH)
 translations = load_translations(config['LANGUAGE'])
 
 # Define consistent colors
-TV_COLOR = config['TV_COLOR']
-MOVIE_COLOR = config['MOVIE_COLOR']
+TV_COLOR = config['TV_COLOR'].strip('"')
+MOVIE_COLOR = config['MOVIE_COLOR'].strip('"')
 
 # Helper function to fetch data from Tautulli
 def fetch_tautulli_data(cmd, params={}):
@@ -68,8 +68,8 @@ def generate_graphs(data, folder, current_translations):
     config = load_config(CONFIG_PATH, reload=True)
     
     # Use the updated color variables
-    TV_COLOR = config['TV_COLOR']
-    MOVIE_COLOR = config['MOVIE_COLOR']
+    TV_COLOR = config['TV_COLOR'].strip('"')
+    MOVIE_COLOR = config['MOVIE_COLOR'].strip('"')
     
     if config['ENABLE_DAILY_PLAY_COUNT']:
         plt.figure(figsize=(14, 8))

--- a/graphs/generate_graphs_user.py
+++ b/graphs/generate_graphs_user.py
@@ -4,10 +4,8 @@ import matplotlib.pyplot as plt
 from datetime import datetime, timedelta
 from matplotlib.ticker import MaxNLocator
 from matplotlib.dates import DateFormatter
-from matplotlib.font_manager import FontProperties
-from graphs.generate_graphs import fetch_tautulli_data, ensure_folder_exists, censor_username
+from graphs.generate_graphs import fetch_tautulli_data, ensure_folder_exists
 import logging
-from i18n import load_translations
 
 # Initialize translations globally
 translations = None

--- a/main.py
+++ b/main.py
@@ -11,7 +11,6 @@ from config.config import load_config
 from i18n import load_translations
 from datetime import datetime
 from graphs.generate_graphs import update_and_post_graphs
-from graphs.generate_graphs_user import generate_user_graphs
 from bot.update_tracker import create_update_tracker
 
 # Get the CONFIG_DIR from environment variable, default to '/config' if not set
@@ -56,7 +55,7 @@ logger = logging.getLogger(__name__)
 
 # Function to print log messages with timestamps
 def log(message, level=logging.INFO):
-    timestamp = datetime.now().astimezone().strftime('%Y-%m-%d %H:%M:%S %Z')
+    datetime.now().astimezone().strftime('%Y-%m-%d %H:%M:%S %Z')
     logger.log(level, message)
 
 # Log that folders have been created
@@ -140,7 +139,7 @@ async def schedule_updates(bot):
     while True:
         if bot.update_tracker.is_update_due():
             log(translations['log_auto_update_started'])
-            config = load_config(args.config_file, reload=True)  # Reload config
+            load_config(args.config_file, reload=True)  # Reload config
             await update_and_post_graphs(bot, translations)
             bot.update_tracker.update()
             next_update_log = bot.update_tracker.get_next_update_readable()

--- a/main.py
+++ b/main.py
@@ -7,7 +7,7 @@ import asyncio
 import discord
 from discord.ext import commands
 from aiohttp import ClientConnectorError, ServerDisconnectedError
-from config.config import load_config
+from config.config import load_config, sanitize_config_file
 from i18n import load_translations
 from datetime import datetime
 from graphs.generate_graphs import update_and_post_graphs
@@ -22,6 +22,10 @@ parser.add_argument('--config-file', type=str, default=os.path.join(CONFIG_DIR, 
 parser.add_argument('--log-file', type=str, default=os.path.join(CONFIG_DIR, 'logs', 'tgraphbot.log'), help='Path to the log file')
 parser.add_argument('--data-folder', type=str, default=os.path.join(CONFIG_DIR, 'data'), help='Path to the data folder')
 args = parser.parse_args()
+
+# Sanitize the config file
+if sanitize_config_file():
+    print("Config file was updated with properly formatted color values.")
 
 # Load configuration
 config = load_config(args.config_file)


### PR DESCRIPTION
**Changelog:**
- Added some checks to make sure the hex code in the `config.yml` is in double quotes (`""`). Otherwise using the `/config` would set the values as `None`, whenever you would change any option.
- Ran a `ruff check --fix` to clear unused imports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved configuration handling for color values with standardized formatting for `TV_COLOR` and `MOVIE_COLOR`.
	- Introduced a sanitation function to clean existing configuration data.

- **Bug Fixes**
	- Enhanced robustness of color value handling to prevent issues with extraneous quotation marks.

- **Documentation**
	- Updated sample configuration file to reflect new string formatting standards for color values.

- **Chores**
	- Streamlined imports in the graph generation scripts for better performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->