### PR TITLE
Fix: Properly format `ANNOTATION_COLORS` 

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -109,7 +109,7 @@ def update_config(key, value):
     global config
     config = load_config(reload=True)
     
-    if key in ['TV_COLOR', 'MOVIE_COLOR']:
+    if key in ['TV_COLOR', 'MOVIE_COLOR', 'ANNOTATION_COLOR']:
         value = format_color_value(str(value))
     
     config[key] = value


### PR DESCRIPTION
Totally broke the bot, if user used `/config`. It would remove the quotes from the `ANNOTATION_COLOR` and make the bot [output errors](https://logs.notifiarr.com/?672a5f8783005007#GfGwTi9SvdpFFffwo3e2vrDNCzqGXvf3qqdwxKij7GfE)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced support for a new color setting, `ANNOTATION_COLOR`, enhancing the configuration update process.
- **Bug Fixes**
	- Improved logic for processing color values during configuration updates, ensuring consistent handling of color settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->